### PR TITLE
Fix quotes in post-excerpt-link

### DIFF
--- a/layout/_partial/article.jade
+++ b/layout/_partial/article.jade
@@ -14,7 +14,7 @@
       !=post.excerpt
       if theme.excerpt_link
         p.post-excerpt-link
-          a(href="!=url_for(post.path)#more") #{theme.excerpt_link}
+          a(href!=url_for(post.path) + "#more") #{theme.excerpt_link}
     else
       !=post.content
   if !index


### PR DESCRIPTION
Fixes following bug:

![image](https://cloud.githubusercontent.com/assets/12968867/10416381/487af77e-7015-11e5-8f9f-ab2bd44a073e.png)
